### PR TITLE
Rename cat-themed bucket list app to Rudimentary

### DIFF
--- a/Rudimentary/Models/BucketItem.swift
+++ b/Rudimentary/Models/BucketItem.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+struct BucketItem: Identifiable, Codable {
+    enum Status: String, Codable, CaseIterable, Identifiable {
+        case planned
+        case inProgress
+        case completed
+
+        var id: String { rawValue }
+
+        var label: String {
+            switch self {
+            case .planned:
+                return "Planned"
+            case .inProgress:
+                return "In Progress"
+            case .completed:
+                return "Completed"
+            }
+        }
+    }
+
+    let id: UUID
+    var title: String
+    var detail: String
+    var category: CatCategory
+    var status: Status
+    var targetSeason: Season?
+    var dateCompleted: Date?
+    var photoIdentifier: String?
+    var loveNote: String
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        detail: String,
+        category: CatCategory,
+        status: Status = .planned,
+        targetSeason: Season? = nil,
+        dateCompleted: Date? = nil,
+        photoIdentifier: String? = nil,
+        loveNote: String = ""
+    ) {
+        self.id = id
+        self.title = title
+        self.detail = detail
+        self.category = category
+        self.status = status
+        self.targetSeason = targetSeason
+        self.dateCompleted = dateCompleted
+        self.photoIdentifier = photoIdentifier
+        self.loveNote = loveNote
+    }
+
+    var celebratoryMessage: String {
+        switch status {
+        case .planned:
+            return "Start plotting this purrfect memory!"
+        case .inProgress:
+            return "Keep prowling forward together."
+        case .completed:
+            return "Paws high! Another memory made."
+        }
+    }
+}

--- a/Rudimentary/Models/CatCategory.swift
+++ b/Rudimentary/Models/CatCategory.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+enum CatCategory: String, CaseIterable, Codable, Identifiable {
+    case cozyNights = "Cozy Nights"
+    case playfulAdventures = "Playful Adventures"
+    case foodieForays = "Foodie Forays"
+    case bigDreams = "Big Dreams"
+    case caringActs = "Caring Acts"
+
+    var id: String { rawValue }
+
+    var iconName: String {
+        switch self {
+        case .cozyNights:
+            return "moon.stars"
+        case .playfulAdventures:
+            return "pawprint"
+        case .foodieForays:
+            return "takeoutbag.and.cup.and.straw"
+        case .bigDreams:
+            return "sparkles"
+        case .caringActs:
+            return "heart"
+        }
+    }
+
+    var palette: CatPalette {
+        switch self {
+        case .cozyNights:
+            return CatPalette(primary: .purrple, secondary: .midnight, accent: .whiskerWhite)
+        case .playfulAdventures:
+            return CatPalette(primary: .ginger, secondary: .blush, accent: .whiskerWhite)
+        case .foodieForays:
+            return CatPalette(primary: .matcha, secondary: .cream, accent: .midnight)
+        case .bigDreams:
+            return CatPalette(primary: .sky, secondary: .lavender, accent: .whiskerWhite)
+        case .caringActs:
+            return CatPalette(primary: .rose, secondary: .cream, accent: .midnight)
+        }
+    }
+}
+
+struct CatPalette: Codable {
+    let primary: ThemeColor
+    let secondary: ThemeColor
+    let accent: ThemeColor
+}
+
+enum Season: String, CaseIterable, Codable, Identifiable {
+    case spring, summer, autumn, winter
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .spring:
+            return "Spring"
+        case .summer:
+            return "Summer"
+        case .autumn:
+            return "Autumn"
+        case .winter:
+            return "Winter"
+        }
+    }
+
+    var emoji: String {
+        switch self {
+        case .spring:
+            return "🌸"
+        case .summer:
+            return "🌞"
+        case .autumn:
+            return "🍁"
+        case .winter:
+            return "❄️"
+        }
+    }
+}

--- a/Rudimentary/Models/ThemeColor.swift
+++ b/Rudimentary/Models/ThemeColor.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+enum ThemeColor: String, Codable {
+    case purrple
+    case midnight
+    case whiskerWhite
+    case ginger
+    case blush
+    case matcha
+    case cream
+    case sky
+    case lavender
+    case rose
+
+    var color: Color {
+        switch self {
+        case .purrple:
+            return Color(red: 140 / 255, green: 105 / 255, blue: 230 / 255)
+        case .midnight:
+            return Color(red: 38 / 255, green: 45 / 255, blue: 68 / 255)
+        case .whiskerWhite:
+            return Color(red: 245 / 255, green: 245 / 255, blue: 240 / 255)
+        case .ginger:
+            return Color(red: 240 / 255, green: 155 / 255, blue: 65 / 255)
+        case .blush:
+            return Color(red: 255 / 255, green: 200 / 255, blue: 210 / 255)
+        case .matcha:
+            return Color(red: 170 / 255, green: 210 / 255, blue: 120 / 255)
+        case .cream:
+            return Color(red: 255 / 255, green: 240 / 255, blue: 210 / 255)
+        case .sky:
+            return Color(red: 150 / 255, green: 210 / 255, blue: 255 / 255)
+        case .lavender:
+            return Color(red: 220 / 255, green: 190 / 255, blue: 255 / 255)
+        case .rose:
+            return Color(red: 245 / 255, green: 120 / 255, blue: 140 / 255)
+        }
+    }
+}
+
+extension Color {
+    static func themed(_ themeColor: ThemeColor) -> Color {
+        themeColor.color
+    }
+}

--- a/Rudimentary/Resources/Assets.xcassets/Contents.json
+++ b/Rudimentary/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Rudimentary/RudimentaryApp.swift
+++ b/Rudimentary/RudimentaryApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct RudimentaryApp: App {
+    @StateObject private var bucketListViewModel = BucketListViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(bucketListViewModel)
+        }
+    }
+}

--- a/Rudimentary/ViewModels/BucketListViewModel.swift
+++ b/Rudimentary/ViewModels/BucketListViewModel.swift
@@ -1,0 +1,116 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class BucketListViewModel: ObservableObject {
+    @Published private(set) var items: [BucketItem]
+    @Published var selectedCategory: CatCategory? = nil
+    @Published var searchText: String = ""
+    @Published var showCompleted: Bool = true
+
+    init(items: [BucketItem] = BucketListViewModel.sampleData) {
+        self.items = items
+    }
+
+    var filteredItems: [BucketItem] {
+        items.filter { item in
+            let matchesCategory = selectedCategory.map { $0 == item.category } ?? true
+            let matchesSearch = searchText.isEmpty || item.title.localizedCaseInsensitiveContains(searchText) || item.detail.localizedCaseInsensitiveContains(searchText)
+            let matchesStatus = showCompleted || item.status != .completed
+            return matchesCategory && matchesSearch && matchesStatus
+        }
+    }
+
+    var progress: Double {
+        guard !items.isEmpty else { return 0 }
+        return Double(completedCount) / Double(items.count)
+    }
+
+    var completedCount: Int {
+        items.filter { $0.status == .completed }.count
+    }
+
+    func items(for status: BucketItem.Status) -> [BucketItem] {
+        filteredItems.filter { $0.status == status }
+    }
+
+    func add(item: BucketItem) {
+        items.append(item)
+    }
+
+    func update(item: BucketItem) {
+        guard let index = items.firstIndex(where: { $0.id == item.id }) else { return }
+        items[index] = item
+    }
+
+    func delete(at offsets: IndexSet, for status: BucketItem.Status) {
+        let statusItems = items(for: status)
+        let idsToDelete = offsets.compactMap { statusItems[safe: $0]?.id }
+        items.removeAll { idsToDelete.contains($0.id) }
+    }
+
+    func remove(item: BucketItem) {
+        items.removeAll { $0.id == item.id }
+    }
+
+    func toggleCompletion(for item: BucketItem) {
+        var updated = item
+        if updated.status == .completed {
+            updated.status = .planned
+            updated.dateCompleted = nil
+        } else {
+            updated.status = .completed
+            updated.dateCompleted = Date()
+        }
+        update(item: updated)
+    }
+}
+
+private extension BucketListViewModel {
+    static let sampleData: [BucketItem] = [
+        BucketItem(
+            title: "Sunset picnic with cat-shaped bento",
+            detail: "Craft adorable kitty rice balls and watch the sunset together at your favorite park.",
+            category: .foodieForays,
+            status: .planned,
+            targetSeason: .summer,
+            loveNote: "Don't forget the sparkling paw-secco!"
+        ),
+        BucketItem(
+            title: "Adopt a houseplant and name it after a cat celebrity",
+            detail: "Pick a leafy friend, design a cute tag, and take progress photos each month.",
+            category: .bigDreams,
+            status: .inProgress,
+            targetSeason: .spring
+        ),
+        BucketItem(
+            title: "Midnight fort movie marathon",
+            detail: "Build a blanket fort, make cocoa, and watch animated cat classics all night.",
+            category: .cozyNights,
+            status: .completed,
+            targetSeason: .winter,
+            dateCompleted: Calendar.current.date(byAdding: .day, value: -12, to: Date()),
+            loveNote: "You make every fort feel like home."
+        ),
+        BucketItem(
+            title: "Volunteer at the local shelter",
+            detail: "Spend a Saturday giving chin scratches, cleaning spaces, and delivering treats.",
+            category: .caringActs,
+            status: .planned,
+            targetSeason: .autumn
+        ),
+        BucketItem(
+            title: "Cat-venture photo scavenger hunt",
+            detail: "Create a list of feline-inspired photo prompts and capture them across the city.",
+            category: .playfulAdventures,
+            status: .planned,
+            targetSeason: .spring
+        )
+    ]
+}
+
+private extension Array {
+    subscript(safe index: Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Rudimentary/Views/AddBucketItemView.swift
+++ b/Rudimentary/Views/AddBucketItemView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+struct AddBucketItemView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var existingItem: BucketItem?
+    var onSave: (BucketItem) -> Void
+
+    @State private var title: String
+    @State private var detail: String
+    @State private var category: CatCategory
+    @State private var status: BucketItem.Status
+    @State private var season: Season?
+    @State private var loveNote: String
+
+    init(existingItem: BucketItem? = nil, onSave: @escaping (BucketItem) -> Void) {
+        self.existingItem = existingItem
+        self.onSave = onSave
+        _title = State(initialValue: existingItem?.title ?? "")
+        _detail = State(initialValue: existingItem?.detail ?? "")
+        _category = State(initialValue: existingItem?.category ?? .cozyNights)
+        _status = State(initialValue: existingItem?.status ?? .planned)
+        _season = State(initialValue: existingItem?.targetSeason)
+        _loveNote = State(initialValue: existingItem?.loveNote ?? "")
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Adventure") {
+                    TextField("Title", text: $title)
+                    TextField("Description", text: $detail, axis: .vertical)
+                        .lineLimit(3...5)
+                }
+
+                Section("Category") {
+                    Picker("Category", selection: $category) {
+                        ForEach(CatCategory.allCases) { category in
+                            Label(category.rawValue, systemImage: category.iconName)
+                                .tag(category)
+                        }
+                    }
+                    .pickerStyle(.navigationLink)
+                }
+
+                Section("Details") {
+                    Picker("Status", selection: $status) {
+                        ForEach(BucketItem.Status.allCases) { status in
+                            Text(status.label).tag(status)
+                        }
+                    }
+
+                    Picker("Season", selection: $season) {
+                        Text("Anytime").tag(Season?.none)
+                        ForEach(Season.allCases) { season in
+                            Text("\(season.displayName) \(season.emoji)").tag(Season?.some(season))
+                        }
+                    }
+                }
+
+                Section("Love note") {
+                    TextField("Add a sweet reminder", text: $loveNote, axis: .vertical)
+                }
+            }
+            .navigationTitle(existingItem == nil ? "New Adventure" : "Edit Adventure")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", role: .cancel) { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                        .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+        }
+    }
+
+    private func save() {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedDetail = detail.trimmingCharacters(in: .whitespacesAndNewlines)
+        var item = existingItem ?? BucketItem(
+            title: trimmedTitle,
+            detail: trimmedDetail,
+            category: category
+        )
+        item.title = trimmedTitle
+        item.detail = trimmedDetail
+        item.category = category
+        item.status = status
+        item.targetSeason = season
+        item.loveNote = loveNote.trimmingCharacters(in: .whitespacesAndNewlines)
+        onSave(item)
+        dismiss()
+    }
+}
+
+#Preview {
+    AddBucketItemView { _ in }
+}

--- a/Rudimentary/Views/BucketItemCard.swift
+++ b/Rudimentary/Views/BucketItemCard.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct BucketItemCard: View {
+    let item: BucketItem
+    let onToggle: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 12) {
+                ZStack {
+                    Circle()
+                        .fill(.themed(item.category.palette.primary).opacity(0.2))
+                        .frame(width: 48, height: 48)
+                    Image(systemName: item.category.iconName)
+                        .font(.title3)
+                        .foregroundStyle(.themed(item.category.palette.primary))
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(item.title)
+                        .font(.headline)
+                        .foregroundStyle(.themed(.midnight))
+                        .multilineTextAlignment(.leading)
+                    Text(item.detail)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.leading)
+                    if let season = item.targetSeason {
+                        Label("Dreaming of \(season.displayName) \(season.emoji)", systemImage: "calendar")
+                            .font(.caption)
+                            .foregroundStyle(.themed(item.category.palette.primary))
+                    }
+                    if !item.loveNote.isEmpty {
+                        Label(item.loveNote, systemImage: "heart")
+                            .font(.caption)
+                            .foregroundStyle(.themed(item.category.palette.accent))
+                            .padding(.top, 2)
+                    }
+                }
+
+                Spacer()
+
+                Button(action: onToggle) {
+                    Image(systemName: item.status == .completed ? "checkmark.circle.fill" : "circle")
+                        .font(.title3.weight(.semibold))
+                        .symbolRenderingMode(.palette)
+                        .foregroundStyle(
+                            item.status == .completed ? .themed(.matcha) : .themed(item.category.palette.primary),
+                            .themed(.whiskerWhite)
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(item.status == .completed ? "Mark as planned" : "Mark as completed")
+            }
+
+            if item.status == .completed, let completedDate = item.dateCompleted {
+                Label("Finished on \(completedDate.formatted(date: .abbreviated, time: .omitted))", systemImage: "sparkles")
+                    .font(.caption)
+                    .foregroundStyle(.themed(.matcha))
+            } else {
+                Text(item.celebratoryMessage)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(.themed(.whiskerWhite).opacity(0.95))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 24, style: .continuous)
+                        .strokeBorder(.themed(item.category.palette.primary).opacity(0.22), lineWidth: 1.5)
+                )
+                .shadow(color: .black.opacity(0.08), radius: 12, x: 0, y: 6)
+        )
+    }
+}
+
+#Preview {
+    BucketItemCard(item: BucketListViewModel().items.first!) {}
+        .padding()
+        .previewLayout(.sizeThatFits)
+}

--- a/Rudimentary/Views/CatMoodHeader.swift
+++ b/Rudimentary/Views/CatMoodHeader.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+struct CatMoodHeader: View {
+    let progress: Double
+    @State private var pawBounce = false
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 18) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .fill(.themed(.lavender).opacity(0.4))
+                    .frame(width: 100, height: 100)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 20, style: .continuous)
+                            .stroke(.themed(.lavender).opacity(0.6), lineWidth: 1.5)
+                    )
+                Image(systemName: catIcon)
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(.themed(.purrple), .themed(.whiskerWhite))
+                    .font(.system(size: 48))
+                    .scaleEffect(pawBounce ? 1.05 : 0.98)
+                    .animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: pawBounce)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(moodTitle)
+                    .font(.title2.weight(.bold))
+                    .foregroundStyle(.themed(.midnight))
+                Text(moodSubtitle)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                HStack(spacing: 6) {
+                    ForEach(0..<5) { index in
+                        Image(systemName: index < Int(progress * 5) ? "heart.fill" : "heart")
+                            .foregroundStyle(.themed(index < Int(progress * 5) ? .rose : .lavender))
+                    }
+                }
+                .font(.footnote)
+            }
+        }
+        .onAppear {
+            pawBounce = true
+        }
+    }
+
+    private var catIcon: String {
+        switch progress {
+        case 0:
+            return "cat"
+        case ..<0.4:
+            return "pawprint.fill"
+        case ..<0.7:
+            return "heart.circle.fill"
+        default:
+            return "sun.max.fill"
+        }
+    }
+
+    private var moodTitle: String {
+        switch progress {
+        case 0:
+            return "New whisker wishes"
+        case ..<0.34:
+            return "Curious kittens"
+        case ..<0.67:
+            return "Purring partners"
+        case ..<0.99:
+            return "Love lions"
+        default:
+            return "Legendary lap cats"
+        }
+    }
+
+    private var moodSubtitle: String {
+        switch progress {
+        case 0:
+            return "Dream up your first memory together."
+        case ..<0.34:
+            return "You're stretching into new adventures."
+        case ..<0.67:
+            return "Snuggled into a cozy rhythm of dates."
+        case ..<0.99:
+            return "Only a few more paw prints to go!"
+        default:
+            return "Every memory is a soft place to land."
+        }
+    }
+}
+
+#Preview {
+    CatMoodHeader(progress: 0.84)
+        .padding()
+        .previewLayout(.sizeThatFits)
+}

--- a/Rudimentary/Views/CategoryPill.swift
+++ b/Rudimentary/Views/CategoryPill.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct CategoryPill: View {
+    let category: CatCategory
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Image(systemName: category.iconName)
+                    .font(.caption.weight(.semibold))
+                Text(category.rawValue)
+                    .font(.caption.weight(.semibold))
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(background)
+            .foregroundStyle(isSelected ? .themed(.whiskerWhite) : .themed(category.palette.primary))
+            .overlay(
+                Capsule().strokeBorder(borderColor, lineWidth: 1.2)
+            )
+            .clipShape(Capsule())
+            .shadow(color: .black.opacity(isSelected ? 0.12 : 0.04), radius: isSelected ? 12 : 4, x: 0, y: isSelected ? 8 : 4)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Filter by \(category.rawValue)")
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+
+    private var background: some View {
+        Capsule()
+            .fill(isSelected ? .themed(category.palette.primary) : .themed(.whiskerWhite).opacity(0.9))
+    }
+
+    private var borderColor: Color {
+        isSelected ? .themed(category.palette.accent) : .themed(category.palette.primary).opacity(0.4)
+    }
+}
+
+#Preview {
+    CategoryPill(category: .playfulAdventures, isSelected: true, action: {})
+        .padding()
+        .previewLayout(.sizeThatFits)
+}

--- a/Rudimentary/Views/ContentView.swift
+++ b/Rudimentary/Views/ContentView.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject private var viewModel: BucketListViewModel
+    @State private var showingAddSheet = false
+    @State private var selectedItem: BucketItem?
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                PawPrintBackground()
+                ScrollView {
+                    VStack(spacing: 24) {
+                        header
+                        statusPicker
+                        ForEach(BucketItem.Status.allCases, id: \.id) { status in
+                            bucketSection(for: status)
+                        }
+                        Spacer(minLength: 24)
+                    }
+                    .padding(.horizontal)
+                    .padding(.top, 16)
+                    .padding(.bottom, 120)
+                }
+            }
+            .navigationTitle("Rudimentary")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    filterMenu
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        showingAddSheet = true
+                    } label: {
+                        Label("Add", systemImage: "plus.circle.fill")
+                            .symbolRenderingMode(.palette)
+                            .foregroundStyle(.themed(.rose), .themed(.whiskerWhite))
+                    }
+                    .accessibilityLabel("Add new bucket list adventure")
+                }
+            }
+        }
+        .searchable(text: $viewModel.searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search adventures")
+        .sheet(item: $selectedItem) { item in
+            AddBucketItemView(existingItem: item) { updated in
+                viewModel.update(item: updated)
+            }
+        }
+        .sheet(isPresented: $showingAddSheet) {
+            AddBucketItemView { newItem in
+                viewModel.add(item: newItem)
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(spacing: 16) {
+            CatMoodHeader(progress: viewModel.progress)
+            CoupleProgressView(
+                progress: viewModel.progress,
+                completedCount: viewModel.completedCount,
+                totalCount: viewModel.items.count
+            )
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .fill(.themed(.whiskerWhite).opacity(0.85))
+                .shadow(color: .themed(.midnight).opacity(0.08), radius: 16, x: 0, y: 8)
+        )
+    }
+
+    private var statusPicker: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 12) {
+                ForEach(CatCategory.allCases) { category in
+                    CategoryPill(category: category, isSelected: viewModel.selectedCategory == category) {
+                        withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+                            viewModel.selectedCategory = viewModel.selectedCategory == category ? nil : category
+                        }
+                    }
+                }
+            }
+            .padding(.vertical, 8)
+            .padding(.horizontal, 4)
+        }
+    }
+
+    private var filterMenu: some View {
+        Menu {
+            Picker("Filter by category", selection: Binding(
+                get: { viewModel.selectedCategory },
+                set: { newValue in
+                    withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+                        viewModel.selectedCategory = newValue
+                    }
+                }
+            )) {
+                Text("All cats").tag(CatCategory?.none)
+                ForEach(CatCategory.allCases) { category in
+                    Label(category.rawValue, systemImage: category.iconName).tag(CatCategory?.some(category))
+                }
+            }
+
+            Toggle(isOn: $viewModel.showCompleted) {
+                Label("Show completed", systemImage: "checkmark.seal")
+            }
+        } label: {
+            Label("Filters", systemImage: "line.3.horizontal.decrease.circle")
+                .labelStyle(.titleAndIcon)
+                .foregroundStyle(.themed(.midnight))
+        }
+        .menuStyle(.borderlessButton)
+    }
+
+    private func bucketSection(for status: BucketItem.Status) -> some View {
+        let items = viewModel.items(for: status)
+        return VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Label(status.label, systemImage: status == .completed ? "checkmark.seal.fill" : "pawprint.fill")
+                    .font(.headline)
+                    .foregroundStyle(status == .completed ? .themed(.matcha) : .themed(.purrple))
+                Spacer()
+                if status == .completed {
+                    Toggle("Show completed", isOn: $viewModel.showCompleted)
+                        .labelsHidden()
+                        .tint(.themed(.matcha))
+                }
+            }
+            .padding(.horizontal, 4)
+
+            if items.isEmpty {
+                EmptySectionView(status: status, selectedCategory: viewModel.selectedCategory)
+            } else {
+                LazyVStack(spacing: 16) {
+                    ForEach(items) { item in
+                        BucketItemCard(item: item) {
+                            viewModel.toggleCompletion(for: item)
+                        }
+                        .onTapGesture {
+                            selectedItem = item
+                        }
+                        .contextMenu {
+                            Button(role: .destructive) {
+                                viewModel.remove(item: item)
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+        .environmentObject(BucketListViewModel())
+}

--- a/Rudimentary/Views/CoupleProgressView.swift
+++ b/Rudimentary/Views/CoupleProgressView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+struct CoupleProgressView: View {
+    let progress: Double
+    let completedCount: Int
+    let totalCount: Int
+
+    var body: some View {
+        VStack(spacing: 16) {
+            ProgressRing(progress: progress)
+                .frame(width: 120, height: 120)
+            VStack(spacing: 6) {
+                Text(progressTitle)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(.themed(.midnight))
+                Text("\(completedCount) of \(totalCount) memories captured")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
+                ShareLink(item: progressShareText) {
+                    Label("Share your progress", systemImage: "square.and.arrow.up")
+                        .font(.footnote.weight(.semibold))
+                }
+                .tint(.themed(.purrple))
+                .padding(.top, 4)
+            }
+        }
+    }
+
+    private var progressTitle: String {
+        switch progress {
+        case 0:
+            return "Let the adventures begin!"
+        case ..<0.34:
+            return "Paws on the path"
+        case ..<0.67:
+            return "Halfway to a cuddly milestone"
+        case ..<0.99:
+            return "Almost purrfection!"
+        default:
+            return "Purrfection achieved!"
+        }
+    }
+
+    private var progressShareText: String {
+        "We have completed \(completedCount) of \(totalCount) adventures in Rudimentary!"
+    }
+}
+
+private struct ProgressRing: View {
+    let progress: Double
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(.themed(.lavender).opacity(0.3), style: StrokeStyle(lineWidth: 14, lineCap: .round))
+            Circle()
+                .trim(from: 0, to: progress)
+                .stroke(
+                    AngularGradient(
+                        gradient: Gradient(colors: [.themed(.purrple), .themed(.rose), .themed(.matcha)]),
+                        center: .center
+                    ),
+                    style: StrokeStyle(lineWidth: 14, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+                .animation(.easeInOut(duration: 0.8), value: progress)
+            Image(systemName: "heart.circle.fill")
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(.themed(.rose), .themed(.whiskerWhite))
+                .font(.system(size: 32))
+        }
+    }
+}
+
+#Preview {
+    CoupleProgressView(progress: 0.72, completedCount: 6, totalCount: 8)
+        .padding()
+        .previewLayout(.sizeThatFits)
+}

--- a/Rudimentary/Views/EmptySectionView.swift
+++ b/Rudimentary/Views/EmptySectionView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct EmptySectionView: View {
+    let status: BucketItem.Status
+    let selectedCategory: CatCategory?
+
+    private var message: String {
+        switch (status, selectedCategory) {
+        case (.planned, .some(let category)):
+            return "No \(category.rawValue.lowercased()) plans yet. Tap + to dream one up!"
+        case (.planned, .none):
+            return "Let's paw-nder your next adventure."
+        case (.inProgress, _):
+            return "Time to chase a new idea together!"
+        case (.completed, .some(let category)):
+            return "No finished memories in \(category.rawValue.lowercased()) yet—keep prowling!"
+        case (.completed, .none):
+            return "Complete an adventure and it will curl up here."
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: status == .completed ? "medal.fill" : "cat")
+                .font(.system(size: 40))
+                .foregroundStyle(.themed(.lavender))
+            Text(message)
+                .font(.subheadline.weight(.medium))
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .strokeBorder(.themed(.lavender).opacity(0.35), lineWidth: 1.4)
+                .background(
+                    RoundedRectangle(cornerRadius: 24, style: .continuous)
+                        .fill(.themed(.whiskerWhite).opacity(0.55))
+                )
+        )
+    }
+}
+
+#Preview {
+    EmptySectionView(status: .planned, selectedCategory: .playfulAdventures)
+        .padding()
+}

--- a/Rudimentary/Views/PawPrintBackground.swift
+++ b/Rudimentary/Views/PawPrintBackground.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct PawPrintBackground: View {
+    var body: some View {
+        LinearGradient(
+            gradient: Gradient(colors: [
+                .themed(.cream).opacity(0.9),
+                .themed(.lavender).opacity(0.4)
+            ]),
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+        .overlay(alignment: .topTrailing) {
+            GeometryReader { _ in
+                Canvas { context, size in
+                    let pawPath = Path { path in
+                        path.addRoundedRect(in: CGRect(x: 0, y: 0, width: 18, height: 22), cornerSize: CGSize(width: 8, height: 8))
+                        path.addEllipse(in: CGRect(x: 12, y: -8, width: 12, height: 12))
+                        path.addEllipse(in: CGRect(x: 4, y: -12, width: 12, height: 12))
+                        path.addEllipse(in: CGRect(x: -4, y: -8, width: 12, height: 12))
+                        path.addEllipse(in: CGRect(x: -10, y: 0, width: 12, height: 12))
+                    }
+
+                    let pawCount = Int(size.width / 70)
+                    for index in 0...pawCount {
+                        let x = CGFloat(index) * 70
+                        let y = CGFloat(index % 2 == 0 ? 40 : 110)
+                        var transform = CGAffineTransform(translationX: x, y: y)
+                        transform = transform.rotated(by: CGFloat(Double(index) * .pi / 8))
+                        let resolvedPath = pawPath.applying(transform)
+                        context.fill(resolvedPath, with: .color(.themed(.purrple).opacity(0.08)))
+                    }
+                }
+            }
+        }
+        .ignoresSafeArea()
+    }
+}
+
+#Preview {
+    PawPrintBackground()
+}

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,37 @@
+# Rudimentary
 
+Rudimentary is a cat-themed bucket list app for couples who want to plan, track, and celebrate shared adventures. The SwiftUI code in this repository can be opened directly in Xcode to explore the app experience.
+
+## Features
+
+- 🐾 **Couple-focused planning** – Capture date ideas, cozy nights, acts of kindness, and big dreams with playful feline flair.
+- 🎯 **Smart filtering** – Search, filter by category, and toggle completed adventures to stay organized.
+- 💖 **Progress insights** – Animated mood header and progress ring celebrate milestones and encourage the next memory.
+- ✍️ **Love notes** – Attach sweet reminders or prompts to each idea to personalize the journey.
+- 📱 **SwiftUI-first** – Built with declarative SwiftUI views, preview support, and modular components ready for adaptation.
+
+## Project structure
+
+```
+Rudimentary/
+├── Models/
+│   ├── BucketItem.swift
+│   ├── CatCategory.swift
+│   └── ThemeColor.swift
+├── ViewModels/
+│   └── BucketListViewModel.swift
+├── Views/
+│   ├── AddBucketItemView.swift
+│   ├── BucketItemCard.swift
+│   ├── CatMoodHeader.swift
+│   ├── CategoryPill.swift
+│   ├── ContentView.swift
+│   ├── CoupleProgressView.swift
+│   ├── EmptySectionView.swift
+│   └── PawPrintBackground.swift
+├── Resources/
+│   └── Assets.xcassets/
+└── RudimentaryApp.swift
+```
+
+To run the project, create a new **App** project in Xcode (iOS ➜ App, interface SwiftUI) named `Rudimentary`, then replace the generated files with the ones from this repository.


### PR DESCRIPTION
## Summary
- rename the SwiftUI target directory and app entry point to Rudimentary
- update in-app copy and share messaging to use the Rudimentary name
- refresh project documentation with the new Rudimentary naming

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dba222c970832db96a44ea68d3d955